### PR TITLE
COPY not ADD

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,5 +5,5 @@ ENV PYTHONUNBUFFERED 1
 RUN mkdir /opt/code && mkdir /opt/requirements
 WORKDIR /opt/code
 
-ADD requirements /opt/requirements
+COPY requirements /opt/requirements
 RUN python3 -m pip install -r /opt/requirements/development.txt


### PR DESCRIPTION
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy

> For other items (files, directories) that do not require ADD’s tar
> auto-extraction capability, you should always use COPY