### PR TITLE
Use raw docker-compose when Getting Started

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A simple Flask webapp to power the 2020 University of Cambridge Freshers' Fair v
 git clone https://github.com/SRCF/lightbluetent.git
 ```
 
-1. Start the containers: `cd lightbluetent` and then `./manage.py compose up -d`
+1. Start the containers: `cd lightbluetent` and then `docker-compose -f docker/development.yml up`
 1. Navigate to localhost:5000 to see the app
 
 ## Application structure


### PR DESCRIPTION
I'm not entirely convinced of the correctness here.

It looks like the `manage.py` script assumes presence of `python` and a
variety of installed libraries, but essentially just wraps
docker-compose.

This commit replaces that instruction with a straight `docker-compose`
call, which solves the problem of the missing dependencies etc., but it
looks like the compose file isn't meant to be used directly, based on
the number of environment variables expected to be set.

So, this commit certainly improves the instructions in that (assuming
you have docker-compose installed) it starts up an instance of the
webapp correctly, but I suspect the environment variables I've skipped
over are important.