### PR TITLE
Use Docker postgres initdb scripts for database creation

### DIFF
--- a/docker/development.yml
+++ b/docker/development.yml
@@ -10,6 +10,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
       - pgdata:/var/lib/postgresql/data
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
   web:
     build:
       context: ${PWD}

--- a/docker/init.sql
+++ b/docker/init.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE lightbluetent;

--- a/docker/testing.yml
+++ b/docker/testing.yml
@@ -10,3 +10,5 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     ports:
       - "5432:5432"
+    volumes:
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql


### PR DESCRIPTION
Rather than DIYing it in manage.py, use the image's Initialization
Scripts feature to create the DB only at initialisation.

See https://hub.docker.com/_/postgres/ for more details.

This also fixes a bug where subsequent runs of `manage.py test` failed
because it tried to create the database every time.