### PR TITLE
Pin PostgreSQL version in Docker Compose

### DIFF
--- a/docker/development.yml
+++ b/docker/development.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   db:
-    image: postgres
+    image: postgres:12
     environment:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}

--- a/docker/testing.yml
+++ b/docker/testing.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   db:
-    image: postgres
+    image: postgres:12
     environment:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}


### PR DESCRIPTION
Current `latest` is 12.4 per https://hub.docker.com/_/postgres/

I've only pinned to 12 on the basis that it wasn't pinned at all, and
any form of specification beat nothing.