### PR TITLE
Rely on default 5432 port for PostgreSQL

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -20,10 +20,6 @@
     "value": "localhost"
   },
   {
-    "name": "POSTGRES_PORT",
-    "value": "5432"
-  },
-  {
     "name": "POSTGRES_PASSWORD",
     "value": "postgres"
   },

--- a/config/testing.json
+++ b/config/testing.json
@@ -20,10 +20,6 @@
     "value": "localhost"
   },
   {
-    "name": "POSTGRES_PORT",
-    "value": "5433"
-  },
-  {
     "name": "POSTGRES_PASSWORD",
     "value": "postgres"
   },

--- a/docker/development.yml
+++ b/docker/development.yml
@@ -8,8 +8,6 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_HOSTNAME: ${POSTGRES_HOSTNAME}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-    ports:
-      - "${POSTGRES_PORT}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
   web:
@@ -23,7 +21,6 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_HOSTNAME: ${POSTGRES_HOSTNAME}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_PORT: ${POSTGRES_PORT}
       FLASK_SECRET_KEY: dummy_secret_key
       FLASK_TRUSTED_HOSTS: ${FLASK_TRUSTED_HOSTS}
     command: flask run --host 0.0.0.0

--- a/docker/testing.yml
+++ b/docker/testing.yml
@@ -9,4 +9,4 @@ services:
       POSTGRES_HOSTNAME: ${POSTGRES_HOSTNAME}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     ports:
-      - "${POSTGRES_PORT}:5432"
+      - "5432:5432"

--- a/lightbluetent/config.py
+++ b/lightbluetent/config.py
@@ -9,7 +9,7 @@ class Config(object):
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_PASSWORD"]
     hostname = os.environ["POSTGRES_HOSTNAME"]
-    port = os.environ["POSTGRES_PORT"]
+    port = int(os.getenv("POSTGRES_PORT", 5432))
     database = os.environ["APPLICATION_DB"]
 
     SQLALCHEMY_DATABASE_URI = (


### PR DESCRIPTION
We're generally unlikely to run on anything different.

I've pulled out the exposed port from development.yml because I don't
think that was intended - we're unlikely to want to connect from outside
the compose environment.

As a result I don't think we generally want or need the custom port
functionality, and can just use the default everywhere.