### PR TITLE
Drop assorted POSTGRES_ env vars in Docker Compose config

### DIFF
--- a/docker/development.yml
+++ b/docker/development.yml
@@ -4,10 +4,7 @@ services:
   db:
     image: postgres:12
     environment:
-      POSTGRES_DB: ${POSTGRES_DB}
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_HOSTNAME: ${POSTGRES_HOSTNAME}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_PASSWORD: password
     volumes:
       - pgdata:/var/lib/postgresql/data
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
@@ -19,9 +16,9 @@ services:
       FLASK_ENV: ${FLASK_ENV}
       FLASK_CONFIG: ${FLASK_CONFIG}
       APPLICATION_DB: ${APPLICATION_DB}
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_HOSTNAME: ${POSTGRES_HOSTNAME}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_USER: postgres
+      POSTGRES_HOSTNAME: db
+      POSTGRES_PASSWORD: password
       FLASK_SECRET_KEY: dummy_secret_key
       FLASK_TRUSTED_HOSTS: ${FLASK_TRUSTED_HOSTS}
     command: flask run --host 0.0.0.0


### PR DESCRIPTION
Since we control the app entirely, we can use default config for the
postgres container, and just pass those values to the web container