### PR TITLE
Redirect to admin page instead of home

### DIFF
--- a/lightbluetent/admin.py
+++ b/lightbluetent/admin.py
@@ -237,6 +237,7 @@ def admin(uid):
                                    page_title=f"Stall administration for { society.name }",
                                    society=society, crsid=crsid, errors=errors,
                                    num_sessions_day_1=num_sessions_day_1, num_sessions_day_2=num_sessions_day_2,
+                                   page_parent=url_for("home.home"),
                                    **values)
         else:
             society.name = values["soc_name"]
@@ -267,7 +268,9 @@ def admin(uid):
 
             db.session.commit()
 
-            return redirect(url_for("home.home"))
+            flash("Settings saved.")
+
+            return redirect(url_for("admin.admin", uid=society.uid))
 
     else:
         # defaults
@@ -289,6 +292,7 @@ def admin(uid):
                            page_title=f"Stall administration for { society.name }",
                            society=society, crsid=crsid, errors={},
                            num_sessions_day_1=num_sessions_day_1, num_sessions_day_2=num_sessions_day_2,
+                           page_parent=url_for("home.home"),
                            **values)
 
 @bp.route("/<uid>/reset_banner")


### PR DESCRIPTION
- After successfully changing settings on the admin page, redirect to the admin page again instead of the home page.
- Add the home page as a parent page of the admin page, so a 'back' arrow (which links to the home page) is provided by base.html.
- Flash a confirmatory message to the admin page on success.