### PR TITLE
404 page: redirect to index instead of home

### DIFF
--- a/lightbluetent/templates/error.html
+++ b/lightbluetent/templates/error.html
@@ -16,7 +16,7 @@
         following below.
         {% endif %}
     </p>
-    <a class="btn btn-primary" href="{{ url_for('home.home') }}">
+    <a class="btn btn-primary" href="{{ url_for('home.index') }}">
         <i class="fa fa-arrow-left mr-2"></i>Go somewhere nice
     </a>
     {%- if tb %}


### PR DESCRIPTION
The home page isn't accessible to non-authenticated users. 