### PR TITLE
Use Javascript to show/hide recurrence options

### DIFF
--- a/lightbluetent/static/javascripts/rooms.js
+++ b/lightbluetent/static/javascripts/rooms.js
@@ -61,6 +61,20 @@ $('input[type="checkbox"]').click(function() {
     }
 });
 
+/* Show the recurring options if they're selected on page load */
+if ($("recurring_checkbox").checked) {
+    $("#recurring_box").show();
+} else {
+    $("#recurring_box").hide();
+}
+
+/* Enable the alias input if selected on page load */
+if ($("alias_checkbox").checked) {
+    $("alias_input").disabled = false;
+} else {
+    $("alias_input").disabled = true;
+}
+
 /* Show or hide the limit settings when the select changes */
 $('#limit_select').change(function() {
     $('.limit_option').hide();

--- a/lightbluetent/templates/rooms/manage.html
+++ b/lightbluetent/templates/rooms/manage.html
@@ -251,7 +251,6 @@
                         Recurring?
                     </label>
                 </div>
-                {% if recurring %}
                 <div id="recurring_box">
                     <div class="input-group mb-3">
                         <div class="input-group-prepend">
@@ -296,7 +295,6 @@
                         </div>
                     </div>
                 </div>
-                {% endif %}
             </article>
         </section>
         {{submit_button()}}


### PR DESCRIPTION
Revert to checking the status of the recurrence check box to show / hide the recurrence options when the room management page is loaded.