### PR TITLE
Asset variants

### DIFF
--- a/lightbluetent/api.py
+++ b/lightbluetent/api.py
@@ -2,6 +2,7 @@ from os import getenv
 from urllib.parse import urlencode
 from hashlib import sha1
 from flask import current_app, url_for
+from lightbluetent.models import Asset
 
 import requests
 import xmltodict
@@ -68,8 +69,9 @@ class Meeting:
         params["password"] = self.moderator_pw
         params["redirect"] = "true"
 
-        if self.logo != current_app.config["DEFAULT_BBB_LOGO"]:
-            logo_path = os.path.join(current_app.config["IMAGES_DIR_FROM_STATIC"], self.logo)
+        if self.logo is not None:
+            logo_subpath = Asset.query.filter_by(key=self.logo).first().path
+            logo_path = os.path.join(current_app.config["IMAGES_DIR_FROM_STATIC"], logo_subpath)
             params["logo"] = url_for("static", filename=logo_path, _external=True)
             params["userdata-bbb_display_branding_area"] = "true"
 
@@ -86,8 +88,9 @@ class Meeting:
         params["password"] = self.attendee_pw
         params["redirect"] = "true"
 
-        if self.logo != current_app.config["DEFAULT_BBB_LOGO"]:
-            logo_path = os.path.join(current_app.config["IMAGES_DIR_FROM_STATIC"], self.logo)
+        if self.logo is not None:
+            logo_subpath = Asset.query.filter_by(key=self.logo).first().path
+            logo_path = os.path.join(current_app.config["IMAGES_DIR_FROM_STATIC"], logo_subpath)
             params["logo"] = url_for("static", filename=logo_path, _external=True)
             params["userdata-bbb_display_branding_area"] = "true"
 

--- a/lightbluetent/models.py
+++ b/lightbluetent/models.py
@@ -31,7 +31,7 @@ class User(db.Model):
 
     # will it work if I use the backref here?
     def __repr__(self):
-        return f"User('{self.crsid}': '{self.full_name}', '{self.email}')"
+        return f"User({self.crsid!r}: {self.full_name!r}, {self.email!r})"
 
 
 class Society(db.Model):
@@ -76,7 +76,7 @@ class Society(db.Model):
     bbb_id = db.Column(db.String, unique=True, nullable=False)
 
     def __repr__(self):
-        return f"Society('{self.name}', '{self.admins}')"
+        return f"Society({self.name!r}, {self.admins!r})"
 
 
 class Setting(db.Model):
@@ -89,7 +89,7 @@ class Setting(db.Model):
     updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
 
     def __repr__(self):
-        return f"Setting('{self.name}', '{self.enabled}')"
+        return f"Setting({self.name!r}, {self.enabled!r})"
 
 
 class Role(db.Model):
@@ -105,7 +105,7 @@ class Role(db.Model):
     users = db.relationship("User", backref="role", lazy=True)
 
     def __repr__(self):
-        return f"Role('{self.name}', '{self.description}')"
+        return f"Role({self.name!r}, {self.description!r})"
 
 
 class Permission(db.Model):
@@ -116,4 +116,4 @@ class Permission(db.Model):
     roles = db.relationship("Role", backref="permission", lazy=True)
 
     def __repr__(self):
-        return f"Permission('{self.name}')"
+        return f"Permission({self.name!r})"

--- a/lightbluetent/models.py
+++ b/lightbluetent/models.py
@@ -61,10 +61,10 @@ class Society(db.Model):
     sessions = db.Column(db.JSON, nullable=True)
     welcome_text = db.Column(db.String, unique=False, nullable=True)
     logo = db.Column(
-        db.String, unique=False, nullable=False, default="default_logo.png"
+        db.String, db.ForeignKey('assets.key'), unique=False, nullable=True
     )
     bbb_logo = db.Column(
-        db.String, unique=False, nullable=False, default="default_bbb_logo.png"
+        db.String, db.ForeignKey('assets.key'), unique=False, nullable=True
     )
     banner_text = db.Column(db.String, unique=False, nullable=True)
     banner_color = db.Column(db.String, unique=False, nullable=True, default="#e8e8e8")

--- a/lightbluetent/models.py
+++ b/lightbluetent/models.py
@@ -117,3 +117,30 @@ class Permission(db.Model):
 
     def __repr__(self):
         return f"Permission({self.name!r})"
+
+
+class Asset(db.Model):
+    """
+    The asset table allows storage of assets, but crucially, allows
+    asset variants to be defined. For example, for image assets one may
+    have HiDPI variants for @1x, @2x, etc; this would be stored as:
+
+        id | key       | variant | path
+        ---|-----------|---------|-------------------------
+         1 | srcf-logo | @1x     | srcf-logo-19a6c2c9.png
+         2 | foo-logo  | NULL    | foo-bar.jpeg
+         3 | srcf-logo | @2x     | srcf-logo-35d372d5.png
+        ...
+
+    """
+
+    __tablename__ = "assets"
+    id = db.Column(db.Integer, primary_key=True)
+    key = db.Column(db.String, unique=False, nullable=False)
+    variant = db.Column(db.String, unique=False, nullable=True)
+    path = db.Column(db.String, unique=True, nullable=False)
+
+    def __repr__(self):
+        if self.variant is None:
+            return f"Asset({self.key!r}: {self.path!r})"
+        return f"Asset({self.key!r}/{self.variant!r}: {self.path!r})"

--- a/lightbluetent/society.py
+++ b/lightbluetent/society.py
@@ -26,9 +26,7 @@ def welcome(uid):
 
     sessions_data = {"days": current_app.config["NUMBER_OF_DAYS"]}
 
-    has_logo = True
-    if society.logo == current_app.config["DEFAULT_LOGO"]:
-        has_logo = False
+    has_logo = society.logo is not None
 
     meeting = Meeting(society)
     running = meeting.is_running()

--- a/lightbluetent/templates/rooms/manage.html
+++ b/lightbluetent/templates/rooms/manage.html
@@ -84,10 +84,9 @@
         </div>
         <div class="col-md-6 px-5">
             <div class="form-group">
-                {% set current_logo = "images/{}".format(society.logo) %}
                 <div class="mx-auto img-thumbnail d-flex align-items-center justify-content-center"
                     style="width:20vmax;height:20vmax;max-width:250px;max-height:250px;">
-                    <img class="img-fluid" style="max-height:100%" src="{{ url_for('static', filename=current_logo) }}"
+                    <img class="img-fluid" style="max-height:100%" {{ society.logo | responsive_image.img }}
                         alt="Society logo" />
                 </div>
             </div>
@@ -110,8 +109,7 @@
     <div class="form-row">
         <div class="col-md-6 px-5">
             <div class="form-group">
-                {% set current_bbb_logo = "images/{}".format(society.bbb_logo) %}
-                <img width="80%" height="250" src="{{ url_for('static', filename=current_bbb_logo) }}"
+                <img width="80%" height="250" {{ society.bbb_logo | responsive_image.img }}
                     alt="Society wide logo" class="img-thumbnail mx-auto d-block">
             </div>
             <div class="form-group">

--- a/lightbluetent/templates/society/welcome.html
+++ b/lightbluetent/templates/society/welcome.html
@@ -11,8 +11,7 @@
     content="{{ _("This is a website for stall management using SRCF Timeout for the 2020 Virtual Freshers' Fair") }}" />
 {% endif %}
 <meta property="og:url" content="{{ request.base_url }}" />
-{% set logo = 'images/' + society.logo %}
-<meta property="og:image" content="{{ url_for('static', filename=logo) }}" />
+<meta property="og:image" content="{{ society.logo | responsive_image.main }}" />
 {% endblock %}
 
 {% block title %}
@@ -21,8 +20,8 @@
 
 {% block static %}
 <link href="{{ url_for('static', filename='styles.css') }}" rel="stylesheet" type="text/css">
-<link href="{{ url_for('static', filename=logo) }}" rel="icon" type="image/x-icon" sizes="16x16 24x24">
-<link href="{{ url_for('static', filename=logo) }}" rel="icon" type="image/svg">
+<link href="{{ society.logo | responsive_image.main }}" rel="icon" type="image/x-icon" sizes="16x16 24x24">
+<link href="{{ society.logo | responsive_image.main }}" rel="icon" type="image/svg">
 {% endblock %}
 
 {% block nav %}
@@ -90,10 +89,9 @@
                 {% endif %}
                 <div class="row no-gutters overflow-hidden">
                     {% if has_logo %}
-                    {% set logo = 'images/' + society.logo %}
                     <div class="col-sm-auto mx-auto mx-md-0 d-flex align-items-center justify-content-center"
                         style="width:100%;max-width:150px;max-height:150px;">
-                        <img class="img-fluid rounded" style="max-height:100%" src="{{ url_for('static', filename=logo) }}"
+                        <img class="img-fluid rounded" style="max-height:100%" {{ society.logo | responsive_image.img }}
                             alt="Logo" role="img" aria-label="Placeholder: Thumbnail" />
                     </div>
                     {% endif %}

--- a/lightbluetent/templates/users/directory.html
+++ b/lightbluetent/templates/users/directory.html
@@ -18,12 +18,11 @@
             </div>
             <div class="card-body">
                 <div id="card-intro" class="d-flex justify-content-between">
-                    {% set current_logo = "images/{}".format(society.logo) %}
-                    {% if society.logo != config["DEFAULT_LOGO"] %}
+                    {% if society.logo is not None %}
                     <div class="flex-shrink-0 ml-3 order-1 d-flex align-items-center justify-content-center"
                         style="width:10vmax;height:10vmax;max-width:112px;max-height:112px;">
                         <img class="img-fluid img-thumbnail" style="max-height:100%"
-                            src="{{ url_for('static', filename=current_logo) }}" alt="Society logo" />
+                            {{ society.logo | responsive_image.img }} alt="Society logo" />
                     </div>
                     {% endif %}
                     <div>

--- a/lightbluetent/templates/users/home.html
+++ b/lightbluetent/templates/users/home.html
@@ -15,12 +15,11 @@
             </div>
             <div class="card-body">
                 <div id="card-intro" class="d-flex justify-content-between align-items-center">
-                    {% set current_logo = "images/{}".format(society.logo) %}
-                    {% if society.logo != config["DEFAULT_LOGO"] %}
+                    {% if society.logo is not None %}
                     <div class="ml-3 order-1 d-flex align-items-center justify-content-center"
                         style="width:14vmax;height:14vmax;max-width:128px;max-height:128px;">
                         <img class="img-fluid img-thumbnail" style="max-height:100%"
-                            src="{{ url_for('static', filename=current_logo) }}" alt="Society logo" />
+                            {{ society.logo | responsive_image.img }} alt="Society logo" />
                     </div>
                     {% endif %}
                     <div>

--- a/lightbluetent/utils.py
+++ b/lightbluetent/utils.py
@@ -1,11 +1,12 @@
+import os
 import uuid
 import re
 import sys
 import requests
-from jinja2 import is_undefined
-from flask import render_template
+from jinja2 import is_undefined, Markup
+from flask import render_template, url_for, current_app
 import traceback
-from lightbluetent.models import db
+from lightbluetent.models import db, Asset
 import re
 import unicodedata
 import hashlib
@@ -241,3 +242,68 @@ def resize_image(image, max_dimensions, *, preserve_aspect=True, grow=False, fil
         if not grow and (out_width > orig_width or out_height > orig_height):
             continue
         yield px_density, image.resize((out_width, out_height))
+
+
+class responsive_image:
+    resp_re = re.compile(r'^@([0-9]+(.[0-9]+)?)x$')
+    def __init__(self, key):
+        main_res = 0
+        main = None
+        variants = {}
+        for variant in Asset.query.filter_by(key=key):
+            path = os.path.join(current_app.config["IMAGES_DIR_FROM_STATIC"], variant.path)
+            path = url_for('static', filename=path)
+            if variant.variant is None:
+                main = path
+                main_res = float('inf')
+            elif (m := resp_re.match(variant.variant)) is not None:
+                v = m.group(1)
+                vf = float(v)
+                if (vf := float(v)) > main_res:
+                    main_res = vf
+                    main = path
+                variants[v] = path
+            else:
+                # should we warn/throw an error?
+                pass
+        self.main = main
+        self.variants = variants
+
+    def img_attr(self, raw=False):
+        srcset = []
+        for res, url in self.variants.items():
+            srcset.append(f"{url} {res}x")
+        srcset = ", ".join(srcset)
+        if srcset:
+            srcset = f" srcset=\"{srcset}\""
+        attrs = f"src=\"{self.main}\"" + srcset
+        if not raw:
+            attrs = Markup(attrs)
+        return attrs
+
+    def css(self, prop='background-image'):
+        # not too widely supported, would be better to provide
+        # tooling for generating appropriate media queries
+
+        srcset = []
+        for res, url in self.variants.items():
+            srcset.append(f"url({url}) {res}x")
+        srcset = ", ".join(srcset)
+        props = f"{prop}:url({self.main});"
+        if srcset:
+            props += f"{prop}:-webkit-image-set({srcset});"
+            props += f"{prop}:image-set({srcset});"
+        if not raw:
+            props = Markup(props)
+        return props
+
+@current_app.template_filter('responsive_image.img')
+def responsive_image_filter_img(key):
+    return responsive_image(key).img_attr()
+@current_app.template_filter('responsive_image.css')
+def responsive_image_filter_css(key, prop='background-image'):
+    return responsive_image(key).css(prop)
+@current_app.template_filter('responsive_image.main')
+def responsive_image_filter_main(key):
+    return responsive_image(key).main
+


### PR DESCRIPTION
This PR works towards being able to show HiDPI image variants by adding a new database table `Assets` with variants associated with asset 'keys' and replacing `society.logo` and `society.bbb_logo` paths with asset keys. In anticipation of multiple variants, the logo deletion functions are updated to remove all variants associated with a given key. 

This will require a schema update:

- Where `society.logo` and `society.bbb_logo` take their default values, i.e. `default_logo.png` and `default_logo_bbb.png` respectively, replace with `NULL`
- Otherwise, create an entry in `assets` with some random key (e.g. `logo:srcf` and `logo-bbb:srcf`), variant as `NULL`, and path as the path to migrate
- Then set `society.logo` to `logo:srcf` and `society.bbb_logo` to `logo-bbb:srcf`