### PR TITLE
Develop asset variants

### DIFF
--- a/lightbluetent/api.py
+++ b/lightbluetent/api.py
@@ -2,6 +2,7 @@ from os import getenv
 from urllib.parse import urlencode
 from hashlib import sha1
 from flask import current_app, url_for
+from lightbluetent.models import Asset
 
 import requests
 import xmltodict
@@ -70,8 +71,10 @@ class Meeting:
         params["password"] = self.moderator_pw
         params["redirect"] = "true"
 
-        '''if self.logo != current_app.config["DEFAULT_ROOM_LOGO"]:
-            logo_path = os.path.join(current_app.config["IMAGES_DIR_FROM_STATIC"], self.logo)
+        '''
+        if self.logo is not None:
+            logo_subpath = Asset.query.filter_by(key=self.logo).first().path
+            logo_path = os.path.join(current_app.config["IMAGES_DIR_FROM_STATIC"], logo_subpath)
             params["logo"] = url_for("static", filename=logo_path, _external=True)
             params["userdata-bbb_display_branding_area"] = "true"
 
@@ -88,8 +91,10 @@ class Meeting:
         params["password"] = self.attendee_pw
         params["redirect"] = "true"
 
-        '''if self.logo != current_app.config["DEFAULT_ROOM_LOGO"]:
-            logo_path = os.path.join(current_app.config["IMAGES_DIR_FROM_STATIC"], self.logo)
+        '''
+        if self.logo is not None:
+            logo_subpath = Asset.query.filter_by(key=self.logo).first().path
+            logo_path = os.path.join(current_app.config["IMAGES_DIR_FROM_STATIC"], logo_subpath)
             params["logo"] = url_for("static", filename=logo_path, _external=True)
             params["userdata-bbb_display_branding_area"] = "true"
 

--- a/lightbluetent/groups.py
+++ b/lightbluetent/groups.py
@@ -5,7 +5,7 @@ from flask import Blueprint, render_template, request, flash, abort, redirect, u
 from lightbluetent.models import db, Group, User, Room, Authentication
 from lightbluetent.users import auth_decorator
 from lightbluetent.api import Meeting
-from lightbluetent.utils import delete_logo, gen_unique_string, gen_room_id, get_form_values
+from lightbluetent.utils import path_sanitise, delete_logo, gen_unique_string, gen_room_id, get_form_values
 from flask_babel import _
 from datetime import datetime
 from PIL import Image
@@ -70,8 +70,9 @@ def update(group_id, update_type):
                 if not delete_logo(group.id):
                     abort(500)
 
+                safe_gid = path_sanitise(group.id)
                 static_filename = (
-                    group.id + "_" + gen_unique_string() + extension
+                    safe_gid + "_" + gen_unique_string() + extension
                 )
 
                 images_dir = current_app.config["IMAGES_DIR"]

--- a/lightbluetent/models.py
+++ b/lightbluetent/models.py
@@ -237,3 +237,30 @@ class Permission(db.Model):
 
     def __repr__(self):
         return f"Permission({self.name!r})"
+
+
+class Asset(db.Model):
+    """
+    The asset table allows storage of assets, but crucially, allows
+    asset variants to be defined. For example, for image assets one may
+    have HiDPI variants for @1x, @2x, etc; this would be stored as:
+
+        id | key       | variant | path
+        ---|-----------|---------|-------------------------
+         1 | srcf-logo | @1x     | srcf-logo-19a6c2c9.png
+         2 | foo-logo  | NULL    | foo-bar.jpeg
+         3 | srcf-logo | @2x     | srcf-logo-35d372d5.png
+        ...
+
+    """
+
+    __tablename__ = "assets"
+    id = db.Column(db.Integer, primary_key=True)
+    key = db.Column(db.String, unique=False, nullable=False)
+    variant = db.Column(db.String, unique=False, nullable=True)
+    path = db.Column(db.String, unique=True, nullable=False)
+
+    def __repr__(self):
+        if self.variant is None:
+            return f"Asset({self.key!r}: {self.path!r})"
+        return f"Asset({self.key!r}/{self.variant!r}: {self.path!r})"

--- a/lightbluetent/models.py
+++ b/lightbluetent/models.py
@@ -78,9 +78,7 @@ class Group(db.Model):
     description = db.Column(db.String, unique=False, nullable=True)
     links = db.relationship("Link", backref="group", lazy=True)
 
-    logo = db.Column(
-        db.String, unique=False, nullable=False, default="default_group_logo.png"
-    )
+    logo = db.Column(db.String, db.ForeignKey('assets.key'), unique=False, nullable=True)
 
     time_created = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)

--- a/lightbluetent/models.py
+++ b/lightbluetent/models.py
@@ -50,7 +50,7 @@ class User(db.Model):
         return perm in [p.name for p in self.role.permissions]
 
     def __repr__(self):
-        return f"User('{self.crsid}': '{self.full_name}', '{self.email}')"
+        return f"User({self.crsid!r}: {self.full_name!r}, {self.email!r})"
 
 
 class Group(db.Model):
@@ -86,7 +86,7 @@ class Group(db.Model):
     updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
 
     def __repr__(self):
-        return f"Group('{self.name}')"
+        return f"Group({self.name!r})"
 
 
 # Different levels of authentication for attendees joining a room
@@ -144,7 +144,7 @@ class Room(db.Model):
     updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
 
     def __repr__(self):
-        return f"Room(group: '{self.group}', name: '{self.name}')"
+        return f"Room(group: {self.group!r}, name: {self.name!r})"
 
 
 class Recurrence(enum.Enum):
@@ -173,7 +173,7 @@ class Session(db.Model):
     limit = db.Column(db.Enum(RecurrenceLimit), nullable=True)
 
     def __repr__(self):
-        return f"Session(group: '{self.group}', start: '{self.start}', end: '{self.end}', reccur: '{self.recur}', limit: '{self.limit}')"
+        return f"Session(group: {self.group!r}, start: {self.start!r}, end: {self.end!r}, reccur: {self.recur!r}, limit: {self.limit!r})"
 
 
 class LinkType(enum.Enum):
@@ -205,7 +205,7 @@ class Setting(db.Model):
     updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
 
     def __repr__(self):
-        return f"Setting('{self.name}', '{self.enabled}')"
+        return f"Setting({self.name!r}, {self.enabled!r})"
 
 
 class Role(db.Model):
@@ -226,7 +226,7 @@ class Role(db.Model):
     users = db.relationship("User", backref="role", lazy=True)
 
     def __repr__(self):
-        return f"Role('{self.name}', '{self.description}')"
+        return f"Role({self.name!r}, {self.description!r})"
 
 
 class Permission(db.Model):
@@ -236,4 +236,4 @@ class Permission(db.Model):
     name = db.Column(db.Enum(PermissionType), unique=False, nullable=False)
 
     def __repr__(self):
-        return f"Permission('{self.name}')"
+        return f"Permission({self.name!r})"

--- a/lightbluetent/rooms.py
+++ b/lightbluetent/rooms.py
@@ -17,7 +17,6 @@ from lightbluetent.users import auth_decorator
 from lightbluetent.api import Meeting
 from lightbluetent.utils import (
     gen_unique_string,
-    delete_logo,
     get_form_values,
     fetch_lookup_data,
     validate_room_alias

--- a/lightbluetent/templates/groups/home.html
+++ b/lightbluetent/templates/groups/home.html
@@ -11,8 +11,7 @@
     content="{{ _("This is a website for event management using SRCF Timeout") }}" />
 {% endif %}
 <meta property="og:url" content="{{ request.base_url }}" />
-{% set logo = 'images/' + group.logo %}
-<meta property="og:image" content="{{ url_for('static', filename=logo) }}" />
+<meta property="og:image" content="{{ group.logo | responsive_image.main }}" />
 {% endblock %}
 
 {% block title %}
@@ -21,8 +20,8 @@
 
 {% block static %}
 <link href="{{ url_for('static', filename='styles.css') }}" rel="stylesheet" type="text/css">
-<link href="{{ url_for('static', filename=logo) }}" rel="icon" type="image/x-icon" sizes="16x16 24x24">
-<link href="{{ url_for('static', filename=logo) }}" rel="icon" type="image/svg">
+<link href="{{ group.logo | responsive_image.main }}" rel="icon" type="image/x-icon" sizes="16x16 24x24">
+<link href="{{ group.logo | responsive_image.main }}" rel="icon" type="image/svg">
 {% endblock %}
 
 {% block nav %}
@@ -80,10 +79,9 @@
                 {% endif %}
                 <div class="row no-gutters overflow-hidden">
                     {% if has_logo %}
-                    {% set logo = 'images/' + group.logo %}
                     <div class="col-sm-auto mx-auto mx-md-0 d-flex align-items-center justify-content-center"
                         style="width:100%;max-width:150px;max-height:150px;">
-                        <img class="img-fluid rounded" style="max-height:100%" src="{{ url_for('static', filename=logo) }}"
+                        <img class="img-fluid rounded" style="max-height:100%" {{ group.logo | responsive_image.img }} 
                             alt="Logo" role="img" aria-label="Placeholder: Thumbnail" />
                     </div>
                     {% endif %}

--- a/lightbluetent/templates/groups/manage.html
+++ b/lightbluetent/templates/groups/manage.html
@@ -52,11 +52,10 @@
             </div>
             <div class="col-lg-6">
                 <div class="form-group">
-                    {% set current_logo = "images/{}".format(group.logo) %}
                     <div class="mx-auto d-flex align-items-center justify-content-center"
                         style="width:20vmax;height:20vmax;max-width:250px;max-height:250px;">
                         <img class="img-fluid img-thumbnail" style="max-height:100%"
-                            src="{{ url_for('static', filename=current_logo) }}" alt="Logo" />
+                            {{ group.logo | responsive_image.img }} alt="Logo" />
                     </div>
                 </div>
                 <div class="form-group">

--- a/lightbluetent/templates/room_aliases/home.html
+++ b/lightbluetent/templates/room_aliases/home.html
@@ -10,10 +10,7 @@
 <meta property="og:description" content="{{ _("This is a website for event management using SRCF Timeout") }}" />
 {% endif %}
 <meta property="og:url" content="{{ request.base_url }}" />
-{% if room.group %}
-{% set logo = 'images/' + room.group.logo %}
-{% endif %}
-<meta property="og:image" content="{{ url_for('static', filename=logo) }}" />
+<meta property="og:image" content="{{ group.logo | responsive_image.main }}" />
 {% endblock %}
 
 {% block title %}
@@ -22,8 +19,8 @@
 
 {% block static %}
 <link href="{{ url_for('static', filename='styles.css') }}" rel="stylesheet" type="text/css">
-<link href="{{ url_for('static', filename=logo) }}" rel="icon" type="image/x-icon" sizes="16x16 24x24">
-<link href="{{ url_for('static', filename=logo) }}" rel="icon" type="image/svg">
+<link href="{{ group.logo | responsive_image.main }}" rel="icon" type="image/x-icon" sizes="16x16 24x24">
+<link href="{{ group.logo | responsive_image.main }}" rel="icon" type="image/svg">
 {% endblock %}
 
 {% block nav %}

--- a/lightbluetent/templates/users/directory.html
+++ b/lightbluetent/templates/users/directory.html
@@ -18,12 +18,11 @@
             </div>
             <div class="card-body">
                 <div id="card-intro" class="d-flex justify-content-between">
-                    {% set current_logo = "images/{}".format(group.logo) %}
-                    {% if group.logo != config["DEFAULT_LOGO"] %}
+                    {% if group.logo is not None %}
                     <div class="flex-shrink-0 ml-3 order-1 d-flex align-items-center justify-content-center"
                         style="width:10vmax;height:10vmax;max-width:112px;max-height:112px;">
                         <img class="img-fluid img-thumbnail" style="max-height:100%"
-                            src="{{ url_for('static', filename=current_logo) }}" alt="Logo" />
+                            {{ group.logo | responsive_image.img }} alt="Logo" />
                     </div>
                     {% endif %}
                     <div>

--- a/lightbluetent/templates/users/home.html
+++ b/lightbluetent/templates/users/home.html
@@ -14,12 +14,11 @@
             <div class="card-header">
             </div>
             <div class="card-body d-flex justify-content-between align-items-center">
-                {% set current_logo = "images/{}".format(group.logo) %}
-                {% if group.logo != config["DEFAULT_GROUP_LOGO"] %}
+                {% if group.logo is not None %}
                 <div class="ml-3 order-1 d-flex align-items-center justify-content-center"
                     style="width:14vmax;height:14vmax;max-width:128px;max-height:128px;">
                     <img class="img-fluid img-thumbnail" style="max-height:100%"
-                        src="{{ url_for('static', filename=current_logo) }}" alt="Group logo" />
+                        {{ group.logo | responsive_image.img }} alt="Group logo" />
                 </div>
                 {% endif %}
                 <div>

--- a/lightbluetent/utils.py
+++ b/lightbluetent/utils.py
@@ -6,7 +6,7 @@ import requests
 from jinja2 import is_undefined
 from flask import render_template, current_app
 import traceback
-from lightbluetent.models import db
+from lightbluetent.models import db, Group, Asset
 from PIL import Image
 import math
 import re
@@ -171,21 +171,6 @@ def fetch_lookup_data(crsid):
     else:
         # something bad happened, don't prefill any fields
         return None
-
-def delete_logo(path):
-
-    images_dir = current_app.config["IMAGES_DIR"]
-
-    if not os.path.isdir(images_dir):
-        current_app.logger.info(f"'{ images_dir }':  no such directory.")
-        abort(500)
-
-    if not os.path.isfile(path):
-        current_app.logger.info(f"no logo to delete")
-        return
-
-    os.remove(path)
-    current_app.logger.info(f"Deleted logo '{ path }'")
 
 def get_form_values(request, keys):
     values = {}

--- a/lightbluetent/utils.py
+++ b/lightbluetent/utils.py
@@ -1,12 +1,13 @@
+import os
 import uuid
 import re
 import os
 import sys
 import requests
-from jinja2 import is_undefined
-from flask import render_template, current_app
+from jinja2 import is_undefined, Markup
+from flask import render_template, url_for, current_app
 import traceback
-from lightbluetent.models import db, Group, Asset
+from lightbluetent.models import db, Asset
 from PIL import Image
 import math
 import re
@@ -262,3 +263,67 @@ def resize_image(image, max_dimensions, *, preserve_aspect=True, grow=False, fil
         if not grow and (out_width > orig_width or out_height > orig_height):
             continue
         yield px_density, image.resize((out_width, out_height))
+
+
+class responsive_image:
+    resp_re = re.compile(r'^@([0-9]+(.[0-9]+)?)x$')
+    def __init__(self, key):
+        main_res = 0
+        main = None
+        variants = {}
+        for variant in Asset.query.filter_by(key=key):
+            path = os.path.join(current_app.config["IMAGES_DIR_FROM_STATIC"], variant.path)
+            path = url_for('static', filename=path)
+            if variant.variant is None:
+                main = path
+                main_res = float('inf')
+            elif (m := resp_re.match(variant.variant)) is not None:
+                v = m.group(1)
+                vf = float(v)
+                if (vf := float(v)) > main_res:
+                    main_res = vf
+                    main = path
+                variants[v] = path
+            else:
+                # should we warn/throw an error?
+                pass
+        self.main = main
+        self.variants = variants
+
+    def img_attr(self, raw=False):
+        srcset = []
+        for res, url in self.variants.items():
+            srcset.append(f"{url} {res}x")
+        srcset = ", ".join(srcset)
+        if srcset:
+            srcset = f" srcset=\"{srcset}\""
+        attrs = f"src=\"{self.main}\"" + srcset
+        if not raw:
+            attrs = Markup(attrs)
+        return attrs
+
+    def css(self, prop='background-image'):
+        # not too widely supported, would be better to provide
+        # tooling for generating appropriate media queries
+
+        srcset = []
+        for res, url in self.variants.items():
+            srcset.append(f"url({url}) {res}x")
+        srcset = ", ".join(srcset)
+        props = f"{prop}:url({self.main});"
+        if srcset:
+            props += f"{prop}:-webkit-image-set({srcset});"
+            props += f"{prop}:image-set({srcset});"
+        if not raw:
+            props = Markup(props)
+        return props
+
+@current_app.template_filter('responsive_image.img')
+def responsive_image_filter_img(key):
+    return responsive_image(key).img_attr()
+@current_app.template_filter('responsive_image.css')
+def responsive_image_filter_css(key, prop='background-image'):
+    return responsive_image(key).css(prop)
+@current_app.template_filter('responsive_image.main')
+def responsive_image_filter_main(key):
+    return responsive_image(key).main

--- a/lightbluetent/utils.py
+++ b/lightbluetent/utils.py
@@ -218,6 +218,8 @@ def resize_image(image, max_dimensions, *, preserve_aspect=True, grow=False, fil
         is placed; (0,0) means top-left, (0.5,0.5) means centered, etc
       hidpi:
         a list of hidpi resolutions to output
+
+    TODO: possible optimisation using reduce here?
     """
 
     if not isinstance(image, Image.Image):


### PR DESCRIPTION
*This is an approximate rebase of `asset-variants` onto `develop` in order to port https://github.com/SRCF/lightbluetent/pull/109 onto v2. The below messages are copied from the original PR.*

---

This PR works towards being able to show HiDPI image variants by adding a new database table `Assets` with variants associated with asset 'keys' and replacing `society.logo` and `society.bbb_logo` paths with asset keys. In anticipation of multiple variants, the logo deletion functions are updated to remove all variants associated with a given key. 

This will require a schema update:

- Where `society.logo` and `society.bbb_logo` take their default values, i.e. `default_logo.png` and `default_logo_bbb.png` respectively, replace with `NULL`
- Otherwise, create an entry in `assets` with some random key (e.g. `logo:srcf` and `logo-bbb:srcf`), variant as `NULL`, and path as the path to migrate
- Then set `society.logo` to `logo:srcf` and `society.bbb_logo` to `logo-bbb:srcf`

---

This PR will require a decent amount of testing to ensure it actually works...

---

Ah, I forgot to update the templates to find the logo urls, best not to thinking about merging this until that's resolved!

Edit: templating done

---

Todo:

- [x] Rebase onto `develop`
- [ ] Test in v2