### PR TITLE
Tool to automate management of database and docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Make someone an admin by running `flask change-role [list of crsids] administrat
 git clone https://github.com/SRCF/lightbluetent.git
 ```
 
-1. Start the containers: `cd lightbluetent` and then `docker-compose -p development -f docker/development.yml up -d`
+1. Start the containers: `cd lightbluetent` and then `./develop.sh up`
 1. Navigate to localhost:5000 to see the app
 
 ## Application structure
@@ -134,6 +134,7 @@ git clone https://github.com/SRCF/lightbluetent.git
 * Remove the env var if you want to perform any database migrations or upgrade, in this case we want to load the variables so psycopg2 can connect
 * `docker-compose -p development -f docker/development.yml up -d` to build and run the Flask container and the PostgreSQL container, attach the `-d` flag optionally to run the containers as daemons in the background
 * `docker-compose -p development -f docker/development.yml down` to tear down the containers
+* `./develop.sh` automates much of the above and below
 
 #### Database management
 

--- a/develop.sh
+++ b/develop.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+scrap() {
+  docker volume rm development_pgdata
+  rm -rf migrations
+}
+
+build() {(
+  set -e
+  cp .sample-env .env
+  docker-compose -p development -f docker/development.yml up -d
+  pipenv install --dev
+  pipenv run -- flask db init
+  pipenv run -- flask db migrate -m 'First migration'
+  pipenv run -- flask db upgrade
+  docker-compose -p development -f docker/development.yml stop
+)}
+
+stop() {
+  docker-compose -p development -f docker/development.yml down
+}
+
+stop_() {
+  stop >/dev/null 2>&1
+}
+
+start() {
+  docker-compose -p development -f docker/development.yml up -d
+}
+
+tail() {
+  docker-compose -p development -f docker/development.yml up
+}
+
+help() {
+cat <<EOF >&2
+Usage: $1 [verb [verb [verb ...]]]
+
+Verbs:
+  help     print this help message
+  build    build docker image, setup db
+  start    run a built image as a daemon
+  tail     run a built image with logging to stdout
+  stop     stop a daemon
+  restart  restart a daemon (= stop start)
+  scrap    flush all related docker and db state
+  rebuild  rebuild in case of schema changes (= scrap build)
+
+  up       (= rebuild tail)
+  down     (= scrap)
+
+Examples:
+  $1 up
+    flush all previous docker/db state, prepare a docker image, populate
+    a fresh db, and start the image with logs output to stdout
+  $1 down
+    stop daemon if running and flush all docker/db state
+EOF
+}
+
+if [[ $# -eq 0 ]]; then
+  help "$0"
+  exit
+fi
+
+for verb in "$@"; do
+  case "$verb" in
+    scrap) stop_; scrap;;
+    start) stop_; start;;
+    restart) stop_; start;;
+    stop) stop;;
+    tail) stop_; tail;;
+    build) stop_; build;;
+    rebuild) stop_; scrap; build;;
+    up) stop_; scrap; build; tail;;
+    down) scrap;;
+    help) help "$0"; exit;;
+    *) 
+      echo "Unrecognised verb: $verb" >&2
+      help "$0" >&2
+      exit 1;;
+  esac
+done


### PR DESCRIPTION
```
Usage: ./develop.sh [verb [verb [verb ...]]]

Verbs:
  help     print this help message
  build    build docker image, setup db
  start    run a built image as a daemon
  tail     run a built image with logging to stdout
  stop     stop a daemon
  restart  restart a daemon (= stop start)
  scrap    flush all related docker and db state
  rebuild  rebuild in case of schema changes (= scrap build)

  up       (= rebuild tail)
  down     (= scrap)

Examples:
  ./develop.sh up
    flush all previous docker/db state, prepare a docker image, populate
    a fresh db, and start the image with logs output to stdout
  ./develop.sh down
    stop daemon if running and flush all docker/db state
```