### PR TITLE
Fix syntax error on directory page

### DIFF
--- a/lightbluetent/templates/users/directory.html
+++ b/lightbluetent/templates/users/directory.html
@@ -56,6 +56,6 @@
 
 {% endif %}
 
-<p>{{ _("Are you a stall manager? <a href=\"%(url)s\">Log in here.</a>", url={{url_for("users.register")}}) }}</p>
+<p>{{ _("Are you a stall manager? <a href=\"%(url)s\">Log in here.</a>", url=url_for("users.register")) }}</p>
 
 {% endblock %}


### PR DESCRIPTION
fixes:

```
File "/societies/cccjcr/lightbluetent/lightbluetent/templates/users/directory.html", line 59, in template
    <p>{{ _("Are you a stall manager? <a href=\"%(url)s\">Log in here.</a>", url={{url_for("users.register")}}) }}</p>
jinja2.exceptions.TemplateSyntaxError: expected token ':', got '}'
```
